### PR TITLE
set statement with a newline breakes the parser

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,5 +8,6 @@ Contributors (in no specific order):
 * @romanoaugusto88
 * @vitalbh
 * @blaubaer
+* Yasin Zähringer
 
 Feel free to add yourself to the list or to modify your entry if you did a contribution.

--- a/testData/statements/set3.tpl
+++ b/testData/statements/set3.tpl
@@ -1,0 +1,5 @@
+{%-
+set variable = 'value'
+-%}
+
+variable: {{ variable }}

--- a/testData/statements/set3.tpl.out
+++ b/testData/statements/set3.tpl.out
@@ -1,0 +1,3 @@
+
+
+variable: value

--- a/tokens/lexer.go
+++ b/tokens/lexer.go
@@ -289,7 +289,7 @@ func (l *Lexer) lexBlock() lexFn {
 	l.Pos += len(l.Config.BlockStartString)
 	l.accept("+-")
 	l.emit(BlockBegin)
-	for isSpace(l.peek()) {
+	for isSpace(l.peek()) || isEndOfLine(l.peek()) {
 		l.next()
 	}
 	if len(l.Current()) > 0 {


### PR DESCRIPTION
the test case:
```
{%-
set variable = 'value'
-%}
```
breaks the parser since it cannot handle the newline after the block starts. fixed by ignoring spaces (already done) and new lines (added in this PR) after a block start.